### PR TITLE
Changed testing screen UI

### DIFF
--- a/addons/WAT/UI/options.gd
+++ b/addons/WAT/UI/options.gd
@@ -1,14 +1,10 @@
-extends HBoxContainer
 tool
-
+extends HBoxContainer
 
 const FILESYSTEM = preload("res://addons/WAT/filesystem.gd")
-onready var FolderSelect: OptionButton = $Folder/Select
-onready var ScriptSelect: OptionButton = $TestScript/Select
-onready var RunAll: Button = $VBox/RunAll
-onready var RunFolder: Button = $Folder/Run
-onready var RunScript: Button = $TestScript/Run
-onready var PrintStrayNodes: Button = $VBox/PrintStrayNodes
+onready var Run: PopupMenu = $Run.get_popup()
+onready var FolderSelect: OptionButton = $SelectDir
+onready var ScriptSelect: OptionButton = $SelectScript
 signal RUN
 
 func _default_directory() -> String:
@@ -31,18 +27,22 @@ func _ready() -> void:
 	_connect()
 
 func _connect():
-	PrintStrayNodes.connect("pressed", self, "print_stray_nodes")
+	Run.connect("id_pressed", self, "call_run_methods")
 	FolderSelect.connect("pressed", self, "_select_folder")
 	ScriptSelect.connect("pressed", self, "_select_script")
-	RunAll.connect("pressed", self, "_run", [], CONNECT_DEFERRED)
-	RunFolder.connect("pressed", self, "_run_folder")
-	RunScript.connect("pressed", self, "_run_script")
-	# We trigger these once before opening them so our popup menu
-	# actually pops up, and doesn't get cut off anymore.
-	# However this also means they appear on first instance
-	# so we need to auto-hide them to look nice
 	ScriptSelect.get_popup().hide()
 	FolderSelect.get_popup().hide()
+
+func call_run_methods(run_id):
+	match run_id:
+		0:
+			_run()
+		1:
+			_run_folder()
+		2:
+			_run_script()
+		4:
+			print_stray_nodes()
 
 func _select_folder(path: String = _default_directory()) -> void:
 	if not Directory.new().dir_exists(path):

--- a/addons/WAT/UI/results.gd
+++ b/addons/WAT/UI/results.gd
@@ -39,7 +39,7 @@ var collapsed: bool = false
 func _expand_all() -> void:
 	for i in self.get_tab_count():
 		get_tab_control(i).expand_all()
-		
+
 func _collapse_all() -> void:
 	for i in self.get_tab_count():
 		get_tab_control(i).collapse_all()

--- a/addons/WAT/WAT.gd
+++ b/addons/WAT/WAT.gd
@@ -1,28 +1,32 @@
-extends PanelContainer
 tool
+extends PanelContainer
 
 # DEFAULTS
 const RUNNER: Script = preload("res://addons/WAT/Runner/runner.gd")
 const FILESYSTEM: Script = preload("res://addons/WAT/filesystem.gd")
 var Runner: Node
 var Results: Node
+var Options: Node
 var run_count: int = 0
 
 func _ready() -> void:
+	Options = $Runner/Options
 	Results = get_node("Runner/Results")
 	Runner = RUNNER.new(FILESYSTEM)
 	Runner.connect("ended", Results, "display")
 	add_child(Runner)
 	Runner.name = Runner.MAIN
-	get_node("Runner/Options").connect("RUN", self, "_run")
+	Options.connect("RUN", self, "_run")
 	Runner.connect("ended", $Runner/Details/Timer, "_stop")
-	set_up_expand_and_collapse()
-	
-func set_up_expand_and_collapse():
-	var expand = get_node("Runner/Options/FormatResults/Expand")
-	var collapse = get_node("Runner/Options/FormatResults/Collapse")
-	expand.connect("pressed", Results, "_expand_all")
-	collapse.connect("pressed", Results, "_collapse_all")
+	var options_view_popup: Node = $Runner/Options/View.get_popup()
+	options_view_popup.connect("id_pressed", self, "set_up_expand_and_collapse")
+
+func set_up_expand_and_collapse(option_id):
+	match option_id:
+		0:
+			Results._expand_all()
+		1:
+			Results._collapse_all()
 
 func _run(path: String) -> void:
 	Results.clear()

--- a/addons/WAT/WAT.tscn
+++ b/addons/WAT/WAT.tscn
@@ -1,9 +1,9 @@
 [gd_scene load_steps=5 format=2]
 
 [ext_resource path="res://addons/WAT/WAT.gd" type="Script" id=1]
-[ext_resource path="res://addons/WAT/UI/results.gd" type="Script" id=2]
-[ext_resource path="res://addons/WAT/Runner/timer.gd" type="Script" id=3]
-[ext_resource path="res://addons/WAT/UI/options.gd" type="Script" id=4]
+[ext_resource path="res://addons/WAT/UI/options.gd" type="Script" id=2]
+[ext_resource path="res://addons/WAT/UI/results.gd" type="Script" id=3]
+[ext_resource path="res://addons/WAT/Runner/timer.gd" type="Script" id=4]
 
 [node name="WAT" type="PanelContainer"]
 margin_right = 1024.0
@@ -20,90 +20,43 @@ margin_bottom = 593.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
-[node name="Results" type="TabContainer" parent="Runner"]
-margin_right = 1010.0
-margin_bottom = 508.0
-size_flags_horizontal = 3
-size_flags_vertical = 3
-custom_constants/top_margin = 0
-custom_constants/side_margin = 0
-tab_align = 0
-script = ExtResource( 2 )
-
-[node name="Details" type="HBoxContainer" parent="Runner"]
-margin_top = 512.0
-margin_right = 1010.0
-margin_bottom = 542.0
-rect_min_size = Vector2( 0, 30 )
-size_flags_horizontal = 3
-custom_constants/separation = 50
-alignment = 1
-
-[node name="Timer" type="Label" parent="Runner/Details"]
-margin_left = 381.0
-margin_top = 8.0
-margin_right = 459.0
-margin_bottom = 22.0
-text = "Not Running"
-script = ExtResource( 3 )
-
-[node name="RunCount" type="Label" parent="Runner/Details"]
-margin_left = 509.0
-margin_top = 8.0
-margin_right = 629.0
-margin_bottom = 22.0
-text = "Ran Tests: 0 Times"
-
 [node name="Options" type="HBoxContainer" parent="Runner"]
-margin_top = 546.0
 margin_right = 1010.0
-margin_bottom = 586.0
+margin_bottom = 20.0
 size_flags_horizontal = 3
 custom_constants/separation = 10
-script = ExtResource( 4 )
+script = ExtResource( 2 )
 
-[node name="VBox" type="VBoxContainer" parent="Runner/Options"]
-margin_right = 245.0
-margin_bottom = 40.0
-size_flags_horizontal = 3
-size_flags_vertical = 3
-custom_constants/separation = 0
-
-[node name="RunAll" type="Button" parent="Runner/Options/VBox"]
-margin_right = 245.0
+[node name="Run" type="MenuButton" parent="Runner/Options"]
+margin_right = 36.0
 margin_bottom = 20.0
-size_flags_horizontal = 3
-size_flags_vertical = 3
-text = "Run All Tests"
+text = "Run"
+items = [ "Run All Tests", null, 0, false, false, 0, 0, null, "", false, "Run Selected Directory", null, 0, false, false, 1, 0, null, "", false, "Run Selected Script", null, 0, false, false, 2, 0, null, "", false, "", null, 0, false, false, 3, 0, null, "", true, "Print Stray Nodes", null, 0, false, false, 4, 0, null, "", false ]
 
-[node name="PrintStrayNodes" type="Button" parent="Runner/Options/VBox"]
-margin_top = 20.0
-margin_right = 245.0
-margin_bottom = 40.0
-size_flags_horizontal = 3
-size_flags_vertical = 3
-text = "Print Stray Nodes"
-
-[node name="Folder" type="VBoxContainer" parent="Runner/Options"]
-editor/display_folded = true
-margin_left = 255.0
-margin_right = 500.0
-margin_bottom = 40.0
-size_flags_horizontal = 3
-size_flags_vertical = 3
-custom_constants/separation = 0
-
-[node name="Run" type="Button" parent="Runner/Options/Folder"]
-margin_right = 245.0
+[node name="View" type="MenuButton" parent="Runner/Options"]
+margin_left = 46.0
+margin_right = 88.0
 margin_bottom = 20.0
-size_flags_horizontal = 3
-size_flags_vertical = 3
-text = "Run Selected Directory"
+text = "View"
+items = [ "Expand All Results", null, 0, false, false, 0, 0, null, "", false, "Collapse All Results", null, 0, false, false, 1, 0, null, "", false ]
 
-[node name="Select" type="OptionButton" parent="Runner/Options/Folder"]
-margin_top = 20.0
-margin_right = 245.0
-margin_bottom = 40.0
+[node name="VSeparator" type="VSeparator" parent="Runner/Options"]
+margin_left = 98.0
+margin_right = 102.0
+margin_bottom = 20.0
+
+[node name="DirLabel" type="Label" parent="Runner/Options"]
+margin_left = 112.0
+margin_top = 3.0
+margin_right = 175.0
+margin_bottom = 17.0
+text = "Directory:"
+align = 1
+
+[node name="SelectDir" type="OptionButton" parent="Runner/Options"]
+margin_left = 185.0
+margin_right = 560.0
+margin_bottom = 20.0
 grow_horizontal = 0
 grow_vertical = 0
 hint_tooltip = "Select A Folder to run tests only from that folder."
@@ -113,49 +66,73 @@ custom_constants/hseparation = 20
 button_mask = 3
 text = "res://tests"
 align = 1
-items = [ "res://tests", null, false, -1, null, "res://tests/FailExamples", null, false, -1, null, "res://tests/WAT", null, false, -1, null, "res://tests/WAT/Bootstrap", null, false, -1, null, "res://tests/WAT/Unit", null, false, -1, null ]
+items = [ "res://tests", null, false, 0, null, "res://tests/FailExamples", null, false, 1, null, "res://tests/WAT", null, false, 2, null, "res://tests/WAT/Bootstrap", null, false, 3, null, "res://tests/WAT/Unit", null, false, 4, null ]
 selected = 0
 
-[node name="TestScript" type="VBoxContainer" parent="Runner/Options"]
-editor/display_folded = true
-margin_left = 510.0
-margin_right = 755.0
-margin_bottom = 40.0
-size_flags_horizontal = 3
-size_flags_vertical = 3
-custom_constants/separation = 0
-
-[node name="Run" type="Button" parent="Runner/Options/TestScript"]
-margin_right = 245.0
+[node name="VSeparator2" type="VSeparator" parent="Runner/Options"]
+margin_left = 570.0
+margin_right = 574.0
 margin_bottom = 20.0
-size_flags_horizontal = 3
-size_flags_vertical = 3
-text = "Run Selected Script"
 
-[node name="Select" type="OptionButton" parent="Runner/Options/TestScript"]
-margin_top = 20.0
-margin_right = 245.0
-margin_bottom = 40.0
-hint_tooltip = "select a single test script to run (your choices depend on which folder is selected)."
-size_flags_horizontal = 3
-size_flags_vertical = 3
+[node name="ScriptLabel" type="Label" parent="Runner/Options"]
+margin_left = 584.0
+margin_top = 3.0
+margin_right = 624.0
+margin_bottom = 17.0
+text = "Script:"
 align = 1
 
-[node name="FormatResults" type="VBoxContainer" parent="Runner/Options"]
-margin_left = 765.0
+[node name="SelectScript" type="OptionButton" parent="Runner/Options"]
+margin_left = 634.0
 margin_right = 1010.0
-margin_bottom = 40.0
+margin_bottom = 20.0
+hint_tooltip = "Select a single test script to run (your choices depend on which folder is selected)."
 size_flags_horizontal = 3
 size_flags_vertical = 3
-custom_constants/separation = 0
+text = "res://tests/yield_example.gd"
+align = 1
+items = [ "res://tests/yield_example.gd", null, false, 0, null ]
+selected = 0
 
-[node name="Expand" type="Button" parent="Runner/Options/FormatResults"]
-margin_right = 245.0
-margin_bottom = 20.0
-text = "Expand All Results"
+[node name="Results" type="TabContainer" parent="Runner"]
+margin_top = 24.0
+margin_right = 1010.0
+margin_bottom = 552.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+custom_constants/top_margin = 0
+custom_constants/side_margin = 0
+tab_align = 0
+drag_to_rearrange_enabled = true
+script = ExtResource( 3 )
 
-[node name="Collapse" type="Button" parent="Runner/Options/FormatResults"]
-margin_top = 20.0
-margin_right = 245.0
-margin_bottom = 40.0
-text = "Collapse All Results"
+[node name="Details" type="HBoxContainer" parent="Runner"]
+editor/display_folded = true
+margin_top = 556.0
+margin_right = 1010.0
+margin_bottom = 586.0
+rect_min_size = Vector2( 0, 30 )
+size_flags_horizontal = 3
+custom_constants/separation = 50
+alignment = 2
+
+[node name="Timer" type="Label" parent="Runner/Details"]
+margin_left = 708.0
+margin_top = 8.0
+margin_right = 786.0
+margin_bottom = 22.0
+text = "Not Running"
+align = 2
+script = ExtResource( 4 )
+
+[node name="VSeparator" type="VSeparator" parent="Runner/Details"]
+margin_left = 836.0
+margin_right = 840.0
+margin_bottom = 30.0
+
+[node name="RunCount" type="Label" parent="Runner/Details"]
+margin_left = 890.0
+margin_top = 8.0
+margin_right = 1010.0
+margin_bottom = 22.0
+text = "Ran Tests: 0 Times"

--- a/addons/WAT/plugin.gd
+++ b/addons/WAT/plugin.gd
@@ -8,27 +8,17 @@ func _enter_tree() -> void:
 	_create_test_folder()
 	_create_temp_folder()
 	interface = UI.instance()
-	get_editor_interface().get_editor_viewport().add_child(interface)
-	make_visible(false)
-
-
+	add_control_to_bottom_panel(interface, "Tests")
 
 func _exit_tree() -> void:
-	get_editor_interface().get_editor_viewport().remove_child(interface)
-	interface.free()
-
-func has_main_screen() -> bool:
-   return true
-
-func make_visible(visible: bool) -> void:
-	interface.show() if visible else interface.hide()
+	remove_control_from_bottom_panel(interface)
 
 func get_plugin_name() -> String:
    return "WAT"
 
 func _create_temp_folder() -> void:
 	Directory.new().make_dir("user://WATemp")
-	
+
 func _create_test_folder() -> void:
 	var title: String = "WAT/Test_Directory"
 	if not ProjectSettings.has_setting(title):


### PR DESCRIPTION
### Description
I moved the testing screen from the main screen to the bottom panel and I changed its UI to be more compact. This makes it easier to modify and test.
Modified on Godot 3.1.2

### Changes
- `plugin.gd` - Replaced lines that added a new Main Screen with a line that added a panel at the bottom of the editor.
- `WAT.tscn` - Moved buttons to `PopupPanel`s under `MenuButton`s. Moved Details to bottom right and `MenuButton`s to top.
- `WAT.gd` - Changed expand/collapse code to connect `id_pressed` to `set_up_expand_and_collapse` and then call relevant methods based on the selected item id.
- `options.gd` - Combined Run signals into code similar to `WAT.gd` and changed Folder and Script selection nodes' paths.