### PR TITLE
Fixed issue where Filesystem _list returned paths with directory and file name separated by two forward slashes

### DIFF
--- a/addons/WAT/filesystem.gd
+++ b/addons/WAT/filesystem.gd
@@ -24,7 +24,7 @@ static func _list(path: String, searching_for: int, include_subdirectories: bool
 	directory.list_dir_begin(true)
 	var name: String = directory.get_next()
 	while name != "":
-		var absolute_path: String = "%s/%s" % [path, name]
+		var absolute_path: String = "%s%s" % [path, name]
 
 		if searching_for == FILE:
 			if name.ends_with(".gd") or name.ends_with(".tres"):


### PR DESCRIPTION
### Description
`filesystem.gd` returns an array of dictionaries and when you try to get the path from any of them, there are 2 forward slashes separating the directory and the file name when there should be only one.

### Example
`FILESYSTEM._list("res://addons/WAT/constants/", FILESYSTEM.FILE, false)`
Result -
```JSON
[{
	"name": "expectation_list.gd",
	"path": "res://addons/WAT/constants//expectation_list.gd"
}, {
	"name": "operators.gd",
	"path": "res://addons/WAT/constants//operators.gd"
}, {
	"name": "type_library.gd",
	"path": "res://addons/WAT/constants//type_library.gd"
}]
```