### PR TITLE
[Draft] Added UI elements to copy script templates

### DIFF
--- a/addons/WAT/UI/icons/more_button.svg
+++ b/addons/WAT/UI/icons/more_button.svg
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   width="16"
+   height="16"
+   viewBox="-27.5 -27.5 16 16"
+   id="svg9"
+   sodipodi:docname="more_button.svg"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+  <metadata
+     id="metadata15">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs13" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1608"
+     inkscape:window-height="1041"
+     id="namedview11"
+     showgrid="true"
+     inkscape:pagecheckerboard="true"
+     showborder="true"
+     borderlayer="false"
+     inkscape:showpageshadow="false"
+     inkscape:snap-object-midpoints="true"
+     inkscape:zoom="35.771086"
+     inkscape:cx="5.8871336"
+     inkscape:cy="8.1097558"
+     inkscape:window-x="305"
+     inkscape:window-y="116"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg9">
+    <inkscape:grid
+       spacingx="1"
+       spacingy="1"
+       empspacing="4"
+       type="xygrid"
+       id="grid4525" />
+  </sodipodi:namedview>
+  <desc
+     id="en">
+	Codes 60-69 General Group: Rain.
+	Code: 64
+	Description: Rain, not freezing, intermittent (heavy at time of observation)
+</desc>
+  <circle
+     id="circle3"
+     r="1.9642856"
+     cx="-19.5"
+     cy="-19.5"
+     style="fill:#e0e0e0;stroke-width:0.35714284" />
+  <circle
+     cy="-24.5"
+     id="circle5"
+     r="1.9642856"
+     cx="-19.5"
+     style="fill:#e0e0e0;stroke-width:0.35714284" />
+  <circle
+     cy="-14.5"
+     id="circle7"
+     r="1.9642856"
+     cx="-19.5"
+     style="fill:#e0e0e0;stroke-width:0.35714284" />
+</svg>

--- a/addons/WAT/UI/icons/more_button.svg.import
+++ b/addons/WAT/UI/icons/more_button.svg.import
@@ -1,0 +1,34 @@
+[remap]
+
+importer="texture"
+type="StreamTexture"
+path="res://.import/more_button.svg-28fca39744c583279c5c29c2415be5b2.stex"
+metadata={
+"vram_texture": false
+}
+
+[deps]
+
+source_file="res://addons/WAT/UI/icons/more_button.svg"
+dest_files=[ "res://.import/more_button.svg-28fca39744c583279c5c29c2415be5b2.stex" ]
+
+[params]
+
+compress/mode=0
+compress/lossy_quality=0.7
+compress/hdr_mode=0
+compress/bptc_ldr=0
+compress/normal_map=0
+flags/repeat=0
+flags/filter=true
+flags/mipmaps=false
+flags/anisotropic=false
+flags/srgb=2
+process/fix_alpha_border=true
+process/premult_alpha=false
+process/HDR_as_SRGB=false
+process/invert_color=false
+stream=false
+size_limit=0
+detect_3d=true
+svg/scale=1.0

--- a/addons/WAT/UI/options.gd
+++ b/addons/WAT/UI/options.gd
@@ -3,8 +3,11 @@ extends HBoxContainer
 
 const FILESYSTEM = preload("res://addons/WAT/filesystem.gd")
 onready var Run: PopupMenu = $Run.get_popup()
+onready var More: PopupMenu = $More.get_popup()
 onready var FolderSelect: OptionButton = $SelectDir
 onready var ScriptSelect: OptionButton = $SelectScript
+var wat_templates_dir: = "res://addons/WAT/script_templates/"
+var script_templates_dir: String
 signal RUN
 
 func _default_directory() -> String:
@@ -28,6 +31,7 @@ func _ready() -> void:
 
 func _connect():
 	Run.connect("id_pressed", self, "call_run_methods")
+	More.connect("id_pressed", self, "more_menu_options")
 	FolderSelect.connect("pressed", self, "_select_folder")
 	ScriptSelect.connect("pressed", self, "_select_script")
 	ScriptSelect.get_popup().hide()
@@ -41,8 +45,40 @@ func call_run_methods(run_id):
 			_run_folder()
 		2:
 			_run_script()
-		4:
+
+func more_menu_options(menu_id):
+	match menu_id:
+		0:
+			prepare_script_templates()
+		1:
 			print_stray_nodes()
+
+func prepare_script_templates():
+	script_templates_dir = ProjectSettings.get_setting("editor/script_templates_search_path")
+	var _dir = Directory.new()
+	if not _dir.dir_exists(script_templates_dir):
+		_dir.make_dir_recursive(script_templates_dir)
+
+	var wat_templates = FILESYSTEM._list(wat_templates_dir, 1, false)
+	var script_templates = FILESYSTEM._list(script_templates_dir, 1, false)
+
+	var templates_exist: = false
+	for i in wat_templates:
+		for j in script_templates:
+			if i.name == j.name:
+				templates_exist = true
+				break
+
+		if templates_exist:
+			$More/Overwrite.popup_centered()
+			# If Ok selected, signal calls `copy_script_templates`
+			break
+
+	if not templates_exist:
+		copy_script_templates()
+
+func copy_script_templates():
+	print_debug("TODO")
 
 func _select_folder(path: String = _default_directory()) -> void:
 	if not Directory.new().dir_exists(path):

--- a/addons/WAT/UI/options.gd
+++ b/addons/WAT/UI/options.gd
@@ -7,6 +7,7 @@ onready var More: PopupMenu = $More.get_popup()
 onready var FolderSelect: OptionButton = $SelectDir
 onready var ScriptSelect: OptionButton = $SelectScript
 var wat_templates_dir: = "res://addons/WAT/script_templates/"
+var wat_templates
 var script_templates_dir: String
 signal RUN
 
@@ -59,7 +60,7 @@ func prepare_script_templates():
 	if not _dir.dir_exists(script_templates_dir):
 		_dir.make_dir_recursive(script_templates_dir)
 
-	var wat_templates = FILESYSTEM._list(wat_templates_dir, 1, false)
+	wat_templates = FILESYSTEM._list(wat_templates_dir, 1, false)
 	var script_templates = FILESYSTEM._list(script_templates_dir, 1, false)
 
 	var templates_exist: = false
@@ -78,7 +79,9 @@ func prepare_script_templates():
 		copy_script_templates()
 
 func copy_script_templates():
-	print_debug("TODO")
+	for i in wat_templates:
+		var _file = load(wat_templates_dir + i.name)
+		ResourceSaver.save(script_templates_dir + "/" + i.name, _file)
 
 func _select_folder(path: String = _default_directory()) -> void:
 	if not Directory.new().dir_exists(path):

--- a/addons/WAT/WAT.tscn
+++ b/addons/WAT/WAT.tscn
@@ -1,9 +1,10 @@
-[gd_scene load_steps=5 format=2]
+[gd_scene load_steps=6 format=2]
 
 [ext_resource path="res://addons/WAT/WAT.gd" type="Script" id=1]
 [ext_resource path="res://addons/WAT/UI/options.gd" type="Script" id=2]
-[ext_resource path="res://addons/WAT/UI/results.gd" type="Script" id=3]
-[ext_resource path="res://addons/WAT/Runner/timer.gd" type="Script" id=4]
+[ext_resource path="res://addons/WAT/UI/icons/more_button.svg" type="Texture" id=3]
+[ext_resource path="res://addons/WAT/UI/results.gd" type="Script" id=4]
+[ext_resource path="res://addons/WAT/Runner/timer.gd" type="Script" id=5]
 
 [node name="WAT" type="PanelContainer"]
 margin_right = 1024.0
@@ -22,22 +23,22 @@ size_flags_vertical = 3
 
 [node name="Options" type="HBoxContainer" parent="Runner"]
 margin_right = 1010.0
-margin_bottom = 20.0
+margin_bottom = 22.0
 size_flags_horizontal = 3
 custom_constants/separation = 10
 script = ExtResource( 2 )
 
 [node name="Run" type="MenuButton" parent="Runner/Options"]
 margin_right = 36.0
-margin_bottom = 20.0
+margin_bottom = 22.0
 text = "Run"
-items = [ "Run All Tests", null, 0, false, false, 0, 0, null, "", false, "Run Selected Directory", null, 0, false, false, 1, 0, null, "", false, "Run Selected Script", null, 0, false, false, 2, 0, null, "", false, "", null, 0, false, false, 3, 0, null, "", true, "Print Stray Nodes", null, 0, false, false, 4, 0, null, "", false ]
+items = [ "Run All Tests", null, 0, false, false, 0, 0, null, "", false, "Run Selected Directory", null, 0, false, false, 1, 0, null, "", false, "Run Selected Script", null, 0, false, false, 2, 0, null, "", false ]
 switch_on_hover = true
 
 [node name="View" type="MenuButton" parent="Runner/Options"]
 margin_left = 46.0
 margin_right = 88.0
-margin_bottom = 20.0
+margin_bottom = 22.0
 text = "View"
 items = [ "Expand All Results", null, 0, false, false, 0, 0, null, "", false, "Collapse All Results", null, 0, false, false, 1, 0, null, "", false ]
 switch_on_hover = true
@@ -45,20 +46,20 @@ switch_on_hover = true
 [node name="VSeparator" type="VSeparator" parent="Runner/Options"]
 margin_left = 98.0
 margin_right = 102.0
-margin_bottom = 20.0
+margin_bottom = 22.0
 
 [node name="DirLabel" type="Label" parent="Runner/Options"]
 margin_left = 112.0
-margin_top = 3.0
+margin_top = 4.0
 margin_right = 175.0
-margin_bottom = 17.0
+margin_bottom = 18.0
 text = "Directory:"
 align = 1
 
 [node name="SelectDir" type="OptionButton" parent="Runner/Options"]
 margin_left = 185.0
-margin_right = 560.0
-margin_bottom = 20.0
+margin_right = 516.0
+margin_bottom = 22.0
 grow_horizontal = 0
 grow_vertical = 0
 hint_tooltip = "Select A Folder to run tests only from that folder."
@@ -68,36 +69,57 @@ custom_constants/hseparation = 20
 button_mask = 3
 text = "res://tests"
 align = 1
-items = [ "res://tests", null, false, -1, null, "res://tests/FailExamples", null, false, -1, null, "res://tests/WAT", null, false, -1, null, "res://tests/WAT/Bootstrap", null, false, -1, null, "res://tests/WAT/Unit", null, false, -1, null ]
+items = [ "res://tests", null, false, 0, null, "res://tests/FailExamples", null, false, 1, null, "res://tests/multix", null, false, 2, null, "res://tests/WAT", null, false, 3, null, "res://tests/WAT/Bootstrap", null, false, 4, null, "res://tests/WAT/Unit", null, false, 5, null ]
 selected = 0
 
 [node name="VSeparator2" type="VSeparator" parent="Runner/Options"]
-margin_left = 570.0
-margin_right = 574.0
-margin_bottom = 20.0
+margin_left = 526.0
+margin_right = 530.0
+margin_bottom = 22.0
 
 [node name="ScriptLabel" type="Label" parent="Runner/Options"]
-margin_left = 584.0
-margin_top = 3.0
-margin_right = 624.0
-margin_bottom = 17.0
+margin_left = 540.0
+margin_top = 4.0
+margin_right = 580.0
+margin_bottom = 18.0
 text = "Script:"
 align = 1
 
 [node name="SelectScript" type="OptionButton" parent="Runner/Options"]
-margin_left = 634.0
-margin_right = 1010.0
-margin_bottom = 20.0
+margin_left = 590.0
+margin_right = 921.0
+margin_bottom = 22.0
 hint_tooltip = "Select a single test script to run (your choices depend on which folder is selected)."
 size_flags_horizontal = 3
 size_flags_vertical = 3
 text = "res://tests/yield_example.gd"
 align = 1
-items = [ "res://tests/yield_example.gd", null, false, -1, null ]
+items = [ "res://tests/yield_example.gd", null, false, 0, null ]
 selected = 0
 
+[node name="VSeparator3" type="VSeparator" parent="Runner/Options"]
+margin_left = 931.0
+margin_right = 935.0
+margin_bottom = 22.0
+
+[node name="More" type="MenuButton" parent="Runner/Options"]
+margin_left = 945.0
+margin_right = 1009.0
+margin_bottom = 22.0
+text = "More"
+icon = ExtResource( 3 )
+items = [ "Add Script Templates", null, 0, false, false, 0, 0, null, "", false, "Print Stray Nodes", null, 0, false, false, 1, 0, null, "", false ]
+
+[node name="Overwrite" type="ConfirmationDialog" parent="Runner/Options/More"]
+margin_right = 200.0
+margin_bottom = 70.0
+popup_exclusive = true
+window_title = "Templates Exist"
+resizable = true
+dialog_text = "Templates already exist. Do you want to overwrite them?"
+
 [node name="Results" type="TabContainer" parent="Runner"]
-margin_top = 24.0
+margin_top = 26.0
 margin_right = 1010.0
 margin_bottom = 552.0
 size_flags_horizontal = 3
@@ -106,10 +128,9 @@ custom_constants/top_margin = 0
 custom_constants/side_margin = 0
 tab_align = 0
 drag_to_rearrange_enabled = true
-script = ExtResource( 3 )
+script = ExtResource( 4 )
 
 [node name="Details" type="HBoxContainer" parent="Runner"]
-editor/display_folded = true
 margin_top = 556.0
 margin_right = 1010.0
 margin_bottom = 586.0
@@ -125,7 +146,7 @@ margin_right = 786.0
 margin_bottom = 22.0
 text = "Not Running"
 align = 2
-script = ExtResource( 4 )
+script = ExtResource( 5 )
 
 [node name="VSeparator" type="VSeparator" parent="Runner/Details"]
 margin_left = 836.0
@@ -138,3 +159,4 @@ margin_top = 8.0
 margin_right = 1010.0
 margin_bottom = 22.0
 text = "Ran Tests: 0 Times"
+[connection signal="confirmed" from="Runner/Options/More/Overwrite" to="Runner/Options" method="copy_script_templates"]

--- a/addons/WAT/WAT.tscn
+++ b/addons/WAT/WAT.tscn
@@ -12,6 +12,9 @@ margin_bottom = 600.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 script = ExtResource( 1 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
 
 [node name="Runner" type="VBoxContainer" parent="."]
 margin_left = 7.0

--- a/addons/WAT/script_templates/WATTemplate.gd
+++ b/addons/WAT/script_templates/WATTemplate.gd
@@ -1,0 +1,25 @@
+extends WATTest
+
+func title():
+	return "TEST GROUP NAME"
+
+func start():
+	# Runs before all test related methods once
+	pass
+
+func pre():
+	# Runs before each test method
+	pass
+
+func test_METHOD():
+	describe("TEST DESCRIPTION")
+	# Create one for each test with a relevant name that MUST start with `test_`
+	pass
+
+func post():
+	# Runs after each test method
+	pass
+
+func end():
+	# Runs after all other test related methods once
+	pass


### PR DESCRIPTION
Couldn't make it actually copy the files because I kept getting errors. So far it just gets the templates directory, checks for file conflicts and prompts the user if any are found.

I originally thought it was because the paths returned by filesystem had 2 forward slashes between the directory and file name. But changing that made `WAT.tscn` crash whenever it was loaded. Error message implied cyclic reference. When I tried using `filesystem.gd` in a different test project with the change, there was no crash.

Trying to copy the files in `WAT/script_templates` using `Directory.copy(...)` but it kept returning `ERR_FILE_CANT_OPEN`. Using `open(...)` and/or `change_dir(...)` did nothing.

I have no clue how to proceed from here so any suggestions are appreciated.