### PR TITLE
Return Yielded Values When Using yield(until_signal())

### DIFF
--- a/Node.gd
+++ b/Node.gd
@@ -1,17 +1,20 @@
 extends Node
 
+func value():
+	var x = 100
+	yield(get_tree().create_timer(1.0), "timeout")
+	return x
+	
+func execute() -> void:
+	var b = value()
+	b.connect("completed", self, "_check")
+	var x = yield(value(), "completed")
+#	print(x == 100)
+	
+func _ready():
+	print([null, null, null])
+	call_deferred("execute")
 
-# Declare member variables here. Examples:
-# var a: int = 2
-# var b: String = "text"
-
-
-# Called when the node enters the scene tree for the first time.
-func _ready() -> void:
-	check(null)
-
-func check(i):
-	print(i is Object)
-# Called every frame. 'delta' is the elapsed time since the previous frame.
-#func _process(delta: float) -> void:
-#	pass
+func _check(value = 5):
+	print(value)
+	print("checking?")

--- a/addons/WAT/test/base_test.gd
+++ b/addons/WAT/test/base_test.gd
@@ -83,3 +83,4 @@ func until_timeout(time_limit: float) -> Node:
 func _notification(what: int) -> void:
 	if what == NOTIFICATION_PREDELETE:
 		direct.clear()
+		_watcher.clear()

--- a/addons/WAT/test/test.gd
+++ b/addons/WAT/test/test.gd
@@ -19,7 +19,7 @@ func _ready() -> void:
 	add_child(_yielder)
 	_start()
 
-func _next():
+func _next(vargs = null):
 	# When yielding until signals or timeouts, this gets called on resume
 	# We call defer here to give the __testcase method time to reach either the end
 	# or an extra yield at which point we're able to check the _state of the yield and

--- a/addons/WAT/test/watcher.gd
+++ b/addons/WAT/test/watcher.gd
@@ -28,7 +28,7 @@ func unwatch(emitter, event: String) -> void:
 		emitter.set_meta("watcher", null)
 		
 func clear() -> void:
+	pass
 	for object in _objects:
-		if object.has_meta("watcher"):
-			object.remove_meta("watcher")
-
+		if is_instance_valid(object):
+			object.set_meta("watcher", null)

--- a/addons/WAT/test/watcher.gd
+++ b/addons/WAT/test/watcher.gd
@@ -1,13 +1,16 @@
 extends Reference
 
 var watching: Dictionary = {}
+var _objects: Array = []
 
 func watch(emitter, event: String) -> void:
+	_objects.append(emitter)
 	if emitter.is_connected(event, self, "_add_emit"):
 		return
 	emitter.set_meta("watcher", self)
 	emitter.connect(event, self, "_add_emit", [emitter, event])
 	watching[event] = {emit_count = 0, calls = []}
+
 
 func _add_emit(a = null, b = null, c = null, d = null, e = null, f = null, g = null, h = null, i = null, j = null, k = null):
 	var arguments: Array = [a, b, c, d, e, f, g, h, i, j, k]
@@ -23,3 +26,9 @@ func unwatch(emitter, event: String) -> void:
 		emitter.disconnect(event, self, "_add_emit")
 		watching.erase(event)
 		emitter.set_meta("watcher", null)
+		
+func clear() -> void:
+	for object in _objects:
+		if object.has_meta("watcher"):
+			object.remove_meta("watcher")
+

--- a/addons/WAT/test/yielder.gd
+++ b/addons/WAT/test/yielder.gd
@@ -35,7 +35,7 @@ func _on_resume(a = null, b = null, c = null, d = null, e = null, f = null) -> v
 	# ..will call "_next" which call defers _change_state. Since it is a deferred
 	# ..call the test will resume first. Therefore if a new yield gets constructed
 	# ..in the interim we will be able to check if we have restarted the yield clock
-	emit_signal("finished")
+	emit_signal("finished", [a, b, c, d, e, f])
 
 func is_active() -> bool:
 	return not paused and time_left > 0

--- a/addons/WAT/ui/metadata/index.tres
+++ b/addons/WAT/ui/metadata/index.tres
@@ -1,8 +1,11 @@
-[gd_resource type="Resource" load_steps=2 format=2]
+[gd_resource type="Resource" load_steps=5 format=2]
 
 [ext_resource path="res://addons/WAT/ui/metadata/index.gd" type="Script" id=1]
+[ext_resource path="res://tests/unit/yield.test.gd" type="Script" id=2]
+[ext_resource path="res://addons/WAT/test/test.gd" type="Script" id=3]
+[ext_resource path="res://addons/WAT/test/base_test.gd" type="Script" id=4]
 
 [resource]
 script = ExtResource( 1 )
-scripts = [  ]
-tags = [  ]
+scripts = [ ExtResource( 2 ), ExtResource( 3 ), ExtResource( 4 ) ]
+tags = [ [  ], [  ], [  ] ]

--- a/project.godot
+++ b/project.godot
@@ -48,7 +48,7 @@ quick_access=Object(FuncRef,"script":null)
 [WAT]
 
 Test_Directory="res://tests"
-ActiveRunPath="res://tests/unit/yield.test.gd"
+ActiveRunPath="res://tests"
 AutoQuit=true
 Goto_Test_Method=Object(FuncRef,"script":null)
 

--- a/project.godot
+++ b/project.godot
@@ -48,7 +48,7 @@ quick_access=Object(FuncRef,"script":null)
 [WAT]
 
 Test_Directory="res://tests"
-ActiveRunPath="res://tests"
+ActiveRunPath="res://tests/unit/yield.test.gd"
 AutoQuit=true
 Goto_Test_Method=Object(FuncRef,"script":null)
 

--- a/tests/unit/yield.test.gd
+++ b/tests/unit/yield.test.gd
@@ -29,7 +29,7 @@ func test_When_we_yield_in_pre():
 	describe("When we yield in pre thrice")
 	asserts.is_true(c, "Then we set var c to true")
 	asserts.is_true(d, "Then we set var d to true")
-	
+
 func test_When_we_yield_in_execute():
 	describe("When we yield twice in execute")
 	yield(until_timeout(0.1), YIELD)
@@ -39,6 +39,19 @@ func test_When_we_yield_in_execute():
 	asserts.is_true(e, "Then we set var e to true")
 	asserts.is_true(f, "Then we set var f to true")
 	
+
+func test_When_we_yield_we_get_the_return_value() -> void:
+	describe("When yield(self.yield_value()) returns")
+	var args = yield(until_signal(yield_value(), "completed", 2.0), YIELD)
+	
+	asserts.is_Array(args, "Then we get an array")
+	asserts.is_equal(args.size(), 6, "Of size 6")
+	asserts.is_equal(args[0], 100, "Where element 0 is 100")
+
+func yield_value() -> int:
+	yield(get_tree().create_timer(1), "timeout")
+	return 100
+
 func test_Yielder_is_not_active_when_asserting():
 	describe("When asserting against a test")
 	yield(until_timeout(0.1), YIELD)
@@ -66,7 +79,7 @@ func test_When_we_call_until_timeout() -> void:
 	asserts.is_true(yielder.is_connected("timeout", yielder, "_on_resume"), "The timeout signal of the yielder is connected")
 	remove_child(yielder)
 	yielder.free()
-	
+
 func test_When_we_call_until_signal() -> void:
 	describe("When we call until signal")
 	var yielder = WAT.Yielder.new()
@@ -77,7 +90,7 @@ func test_When_we_call_until_signal() -> void:
 	asserts.is_true(is_connected("abc", yielder, "_on_resume"), "Then our signal is connected to the yielder")
 	remove_child(yielder)
 	yielder.free()
-	
+
 func test_When_the_yielder_times_out() -> void:
 	describe("When the yielder times out on until_timeout(0.1)")
 	yield(until_timeout(0.1), YIELD)
@@ -92,5 +105,3 @@ func test_When_the_yielder_hears_our_signal() -> void:
 	asserts.is_true(_yielder.paused, "Then the yielder is paused")
 	asserts.is_true(not _yielder.is_connected("timeout", _yielder, "_on_resume"), "Then the timeout signal of the yielder is disconnected")
 	asserts.is_true(not is_connected("abc", _yielder, "_on_resume"), "Then our signal to the yielder is disconnected")
-#	remove_child(yielder)
-	

--- a/tests/unit/yield.test.gd
+++ b/tests/unit/yield.test.gd
@@ -1,7 +1,7 @@
 extends WAT.Test
 
 var a; var b; var c; var d; var e; var f;
-# warning-ignore:unused_signal 
+## warning-ignore:unused_signal 
 signal abc # (its used by call_defferred)
 
 func title() -> String:
@@ -38,18 +38,19 @@ func test_When_we_yield_in_execute():
 	f = true
 	asserts.is_true(e, "Then we set var e to true")
 	asserts.is_true(f, "Then we set var f to true")
-	
+
 
 func test_When_we_yield_we_get_the_return_value() -> void:
 	describe("When yield(self.yield_value()) returns")
-	var args = yield(until_signal(yield_value(), "completed", 2.0), YIELD)
 	
+	var args: Array = yield(until_signal(yield_value(), "completed", 0.5), YIELD)
+
 	asserts.is_Array(args, "Then we get an array")
 	asserts.is_equal(args.size(), 6, "Of size 6")
 	asserts.is_equal(args[0], 100, "Where element 0 is 100")
 
 func yield_value() -> int:
-	yield(get_tree().create_timer(1), "timeout")
+	yield(get_tree().create_timer(0.1), "timeout")
 	return 100
 
 func test_Yielder_is_not_active_when_asserting():
@@ -69,7 +70,7 @@ func test_When_yielder_is_finished_signals_are_disconnected():
 	yield(until_signal(self, "abc", 0.1), YIELD)
 	asserts.is_true(not _yielder.is_connected("timeout", _yielder, "_on_resume"), "Then the timeout signal is disconnected")
 	asserts.is_true(not is_connected("abc", _yielder, "_on_resume"), "Then the signal-signal is disconnected")
-
+#
 func test_When_we_call_until_timeout() -> void:
 	describe("When we call until_timeout (with 1.0)")
 	var yielder = WAT.Yielder.new()
@@ -79,7 +80,7 @@ func test_When_we_call_until_timeout() -> void:
 	asserts.is_true(yielder.is_connected("timeout", yielder, "_on_resume"), "The timeout signal of the yielder is connected")
 	remove_child(yielder)
 	yielder.free()
-
+#
 func test_When_we_call_until_signal() -> void:
 	describe("When we call until signal")
 	var yielder = WAT.Yielder.new()


### PR DESCRIPTION
Resolves #90

Users can now receive a return value from arguments by using WAT's until_signal() value. Up to 6 unique values can be returned this way.

```
var result: Array = yield(function_that_yields(), "completed", 1.0), YIELD)
```

When returning from a yielding function, the first value of this result array is that returned value. When getting them from signals, it depends on how they were passed (bound vs not).
